### PR TITLE
Include ExternalIds Data

### DIFF
--- a/SpotifyExplode/Albums/Album.cs
+++ b/SpotifyExplode/Albums/Album.cs
@@ -50,6 +50,12 @@ public class Album
     [JsonPropertyName("genres")]
     public List<string> Genres { get; set; } = default!;
 
+    /// <summary>
+    /// Known external IDs for the track.
+    /// </summary>
+    [JsonPropertyName("external_ids")]
+    public ExternalIds? ExternalIds { get; set; } = default!;
+    
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     public override string ToString() => $"Album ({Name})";

--- a/SpotifyExplode/Common/ExternalIds.cs
+++ b/SpotifyExplode/Common/ExternalIds.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace SpotifyExplode.Common;
+
+public class ExternalIds
+{
+    /// <summary>
+    /// International Standard Recording Code
+    /// </summary>
+    [JsonPropertyName("isrc")]
+    public string? IsrcCode { get; set; }
+
+    /// <summary>
+    /// International Article Number
+    /// </summary>
+    [JsonPropertyName("ean")]
+    public string? EanCode { get; set; }
+
+    /// <summary>
+    /// Universal Product Code
+    /// </summary>
+    [JsonPropertyName("upc")]
+    public string? UpcCode { get; set; }
+}

--- a/SpotifyExplode/Tracks/Track.cs
+++ b/SpotifyExplode/Tracks/Track.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using SpotifyExplode.Albums;
 using SpotifyExplode.Artists;
+using SpotifyExplode.Common;
 
 namespace SpotifyExplode.Tracks;
 
@@ -49,6 +50,12 @@ public class Track
     [JsonPropertyName("album")]
     public Album Album { get; set; } = default!;
 
+    /// <summary>
+    /// Known external IDs for the track.
+    /// </summary>
+    [JsonPropertyName("external_ids")]
+    public ExternalIds? ExternalIds { get; set; } = default!;
+    
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     public override string ToString() => $"Track ({Title})";


### PR DESCRIPTION
Request for Including the spotify external Ids object data when getting track/album data as seen in spotify official documentation:
https://developer.spotify.com/documentation/web-api/reference/get-track
https://developer.spotify.com/documentation/web-api/reference/get-an-album

I need those for the ISRC codes.
The ExternalIds class is in Common folder since its present in Tracks and Albums.